### PR TITLE
feat: @handler support

### DIFF
--- a/packages/faas/test/fixtures/base-app-handler/index.js
+++ b/packages/faas/test/fixtures/base-app-handler/index.js
@@ -1,0 +1,12 @@
+const { FaaSStarter } = require('@midwayjs/faas');
+
+let starter;
+
+exports.initialize = async ({ config } = {}) => {
+  starter = new FaaSStarter({ config, baseDir: __dirname });
+  await starter.start();
+};
+
+exports.handler = async (...args) => {
+  return starter.handleInvokeWrapper('index.handler')(...args);
+};

--- a/packages/faas/test/fixtures/base-app-handler/package.json
+++ b/packages/faas/test/fixtures/base-app-handler/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "demo-app"
+}

--- a/packages/faas/test/fixtures/base-app-handler/src/index.ts
+++ b/packages/faas/test/fixtures/base-app-handler/src/index.ts
@@ -1,0 +1,19 @@
+import { Inject, Provide, Func, Handler } from '@midwayjs/decorator';
+import { FunctionHandler } from '../../../../src';
+
+@Provide()
+@Func('')
+export class IndexService implements FunctionHandler {
+  @Inject()
+  ctx; // context
+
+  @Handler('index.entry')
+  handler(event) {
+    return event.text + this.ctx.text;
+  }
+
+  @Handler('index.list')
+  getList(event) {
+    return event.text + this.ctx.text;
+  }
+}

--- a/packages/faas/test/fixtures/base-app-handler2/index.js
+++ b/packages/faas/test/fixtures/base-app-handler2/index.js
@@ -1,0 +1,12 @@
+const { FaaSStarter } = require('@midwayjs/faas');
+
+let starter;
+
+exports.initialize = async ({ config } = {}) => {
+  starter = new FaaSStarter({ config, baseDir: __dirname });
+  await starter.start();
+};
+
+exports.handler = async (...args) => {
+  return starter.handleInvokeWrapper('index.handler')(...args);
+};

--- a/packages/faas/test/fixtures/base-app-handler2/package.json
+++ b/packages/faas/test/fixtures/base-app-handler2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "demo-app"
+}

--- a/packages/faas/test/fixtures/base-app-handler2/src/index.ts
+++ b/packages/faas/test/fixtures/base-app-handler2/src/index.ts
@@ -1,0 +1,19 @@
+import { Inject, Provide, Func, Handler } from '@midwayjs/decorator';
+import { FunctionHandler } from '../../../../src';
+
+@Provide()
+@Func('index.handler')
+export class IndexService implements FunctionHandler {
+  @Inject()
+  ctx; // context
+
+  // index.handler default method
+  handler(event) {
+    return event.text + this.ctx.text;
+  }
+
+  @Handler('index.list')
+  getList(event) {
+    return event.text + this.ctx.text;
+  }
+}

--- a/packages/faas/test/index.test.ts
+++ b/packages/faas/test/index.test.ts
@@ -72,6 +72,40 @@ describe('test/index.test.ts', () => {
     });
   });
 
+  describe('use default handler and new handler', () => {
+    let mock;
+    before(async () => {
+      mock = await createServerlessMock({
+        baseDir: join(__dirname, './fixtures/base-app-handler2'),
+        typescript: true,
+      });
+    });
+
+    it('invoke default @fun handler', done => {
+      return mock
+        .handler('index.handler')
+        .invoke(
+          {
+            text: 'hello',
+          },
+          { text: 'a' }
+        )
+        .expect(/ahello/, done);
+    });
+
+    it('invoke new decorator handler', done => {
+      return mock
+        .handler('index.list')
+        .invoke(
+          {
+            text: 'hello',
+          },
+          { text: 'a' }
+        )
+        .expect(/ahello/, done);
+    });
+  });
+
   describe('change default route', () => {
     it('invoke handler by appoint function route', async () => {
       const mock = await createServerlessMock({

--- a/packages/faas/test/index.test.ts
+++ b/packages/faas/test/index.test.ts
@@ -38,6 +38,40 @@ describe('test/index.test.ts', () => {
     });
   });
 
+  describe('change default handler', () => {
+    let mock;
+    before(async () => {
+      mock = await createServerlessMock({
+        baseDir: join(__dirname, './fixtures/base-app-handler'),
+        typescript: true,
+      });
+    });
+
+    it('invoke handler one', done => {
+      return mock
+        .handler('index.entry')
+        .invoke(
+          {
+            text: 'hello',
+          },
+          { text: 'a' }
+        )
+        .expect(/ahello/, done);
+    });
+
+    it('invoke handler two', done => {
+      return mock
+        .handler('index.list')
+        .invoke(
+          {
+            text: 'hello',
+          },
+          { text: 'a' }
+        )
+        .expect(/ahello/, done);
+    });
+  });
+
   describe('change default route', () => {
     it('invoke handler by appoint function route', async () => {
       const mock = await createServerlessMock({
@@ -130,7 +164,7 @@ describe('test/index.test.ts', () => {
       mock = await createServerlessMock({
         baseDir: join(__dirname, './fixtures/base-app-configuration'),
         typescript: true,
-        configurationTest: true
+        configurationTest: true,
       });
     });
 


### PR DESCRIPTION
```ts
@Provide()
@Func('')     // TODO midway/decorator allow undefined
export class IndexService implements FunctionHandler {
  @Inject()
  ctx; // context

  @Handler('index.entry')
  handler(event) {
    return event.text + this.ctx.text;
  }

  @Handler('index.list')
  getList(event) {
    return event.text + this.ctx.text;
  }
}
```

the `@fun` and `@handler`, can be used in same time. such as:

```ts
import { Inject, Provide, Func, Handler } from '@midwayjs/decorator';
import { FunctionHandler } from '../../../../src';

@Provide()
@Func('index.handler')
export class IndexService implements FunctionHandler {
  @Inject()
  ctx; // context

  // index.handler default method
  handler(event) {
    return event.text + this.ctx.text;
  }

  @Handler('index.list')
  getList(event) {
    return event.text + this.ctx.text;
  }
}
```