### PR TITLE
fix: cli help

### DIFF
--- a/packages/faas-cli-plugin-test/src/index.ts
+++ b/packages/faas-cli-plugin-test/src/index.ts
@@ -32,7 +32,6 @@ export class TestPlugin extends BasePlugin {
 
   hooks = {
     'test:test': async () => {
-      console.log('f', this.options.f);
       const servicePath = this.core.config.servicePath;
       let testFiles = [];
       if (this.options.f) {

--- a/packages/faas-cli-plugin-test/src/index.ts
+++ b/packages/faas-cli-plugin-test/src/index.ts
@@ -22,16 +22,27 @@ export class TestPlugin extends BasePlugin {
           usage: 'set mocha reporter',
           shortcut: 'r',
         },
+        file: {
+          usage: 'specify a test file',
+          shortcut: 'f',
+        },
       },
     },
   };
 
   hooks = {
     'test:test': async () => {
-      this.core.cli.log('Testing all *.test.js/ts...');
+      console.log('f', this.options.f);
+      const servicePath = this.core.config.servicePath;
+      let testFiles = [];
+      if (this.options.f) {
+        testFiles = [this.options.f];
+        this.core.cli.log(`Testing ${this.options.f}`);
+      } else {
+        this.core.cli.log('Testing all *.test.js/ts...');
+      }
       const options = this.options;
       const Command = options.cov ? CovCommand : TestCommand;
-      const servicePath = this.core.config.servicePath;
       const tester = new Command();
       await co(function*() {
         process.env.TS_NODE_FILES = 'true';
@@ -39,7 +50,7 @@ export class TestPlugin extends BasePlugin {
           cwd: servicePath,
           env: process.env,
           argv: Object.assign(process.argv, {
-            _: [],
+            _: testFiles,
             nyc: '--reporter=json --reporter=lcov --reporter=text',
             watch: options.watch,
             extension: 'ts,js',

--- a/packages/faas-cli-plugin-test/test/a.test.ts
+++ b/packages/faas-cli-plugin-test/test/a.test.ts
@@ -1,0 +1,6 @@
+import * as assert from 'assert';
+describe('/test/a.test.ts', () => {
+  it('testA', async () => {
+    assert(true);
+  });
+});

--- a/packages/faas-cli-plugin-test/test/b.test.ts
+++ b/packages/faas-cli-plugin-test/test/b.test.ts
@@ -1,0 +1,6 @@
+import * as assert from 'assert';
+describe('/test/b.test.ts', () => {
+  it('testB', async () => {
+    assert(true);
+  });
+});

--- a/packages/faas-cli/src/index.ts
+++ b/packages/faas-cli/src/index.ts
@@ -70,7 +70,11 @@ export class CLI extends BaseCLI {
 
   async checkProvider() {
     // ignore f -v / f -h / f create
-    if (!this.commands.length || this.argv.h || this.commands[0] === 'create') {
+    if (!this.commands.length || this.argv.h) {
+      return;
+    }
+    const skipCommands = ['create', 'test'];
+    if (skipCommands.indexOf(this.commands[0]) !== -1) {
       return;
     }
     if (!this.spec.provider) {

--- a/packages/faas-cli/src/index.ts
+++ b/packages/faas-cli/src/index.ts
@@ -6,6 +6,7 @@ import { DeployPlugin } from '@midwayjs/fcli-plugin-deploy';
 import { AliyunFCPlugin } from '@midwayjs/fcli-plugin-fc';
 import { CreatePlugin } from '@midwayjs/fcli-plugin-create';
 import { saveYaml } from '@midwayjs/serverless-spec-builder';
+import { execSync } from 'child_process';
 const { Select } = require('enquirer');
 export class CLI extends BaseCLI {
   loadDefaultPlugin() {
@@ -35,13 +36,31 @@ export class CLI extends BaseCLI {
     }
   }
 
-  displayVersion() {
-    let version = '';
-    try {
-      version = require('../package.json').version;
-    } catch (E) {}
+  loadExtensions() {
+    return {
+      debug: this.debug
+    };
+  }
+
+  debug(...args) {
+    if (!this.argv.V && !this.argv.verbose) {
+      return;
+    }
     const log = this.loadLog();
-    log.log(`@midwayjs/faas-cli v${version}`);
+    log.log(...args);
+  }
+
+  displayVersion() {
+    const log = this.loadLog();
+    try {
+      const nodeVersion = execSync('node -v').toString().replace('\n', '');
+      log.log('Node.js'.padEnd(20) + nodeVersion);
+    } catch (E) {}
+
+    try { // midway-faas version
+      const cliVersion = require('../package.json').version;
+      log.log('@midwayjs/faas-cli'.padEnd(20) + `v${cliVersion}`);
+    } catch (E) {}
   }
 
   displayUsage(commandsArray, usage, coreInstance) {


### PR DESCRIPTION
+ f test 支持指定文件
+ f test 跳过provider平台检查
+ 在插件中可以通过 this.core.debug 获取到 verbose 方法
+ f -v 展示 cli与node版本