### PR TITLE
feat(faas-cli): enable local devevelopment source-map support

### DIFF
--- a/packages/faas-cli/bin/fun.js
+++ b/packages/faas-cli/bin/fun.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 'use strict';
+
+require('source-map-support/register');
+
 const { CLI } = require('../dist');
 const cli = new CLI(process.argv);
 cli.start();


### PR DESCRIPTION
Mapping error stacks to original source file locations.