### PR TITLE
fix: cli performance

### DIFF
--- a/benchmark/cli.js
+++ b/benchmark/cli.js
@@ -10,9 +10,17 @@ const baseApp = resolve(
 const func = () => {
   cp.execSync(`cd ${baseApp};${cli} invoke -f http --clean=false`);
 };
+const funcHelp = () => {
+  cp.execSync(`${cli} -h`);
+};
+const funcTest = () => {
+  cp.execSync(`${cli} test -f ${resolve(__dirname, './bc.test.ts')}`);
+};
 
 const contenders = {
   'faas-cli invoke': func,
+  'faas-cli help': funcHelp,
+  'faas-cli test': funcTest,
 };
 
 console.log('\nBenchmark:');

--- a/benchmark/cli.js
+++ b/benchmark/cli.js
@@ -1,0 +1,27 @@
+const { Suite } = require('benchmark');
+const { resolve } = require('path');
+const cp = require('child_process');
+const cli = resolve(__dirname, '../packages/faas-cli/bin/fun.js');
+const baseApp = resolve(
+  __dirname,
+  '../packages/serverless-invoke/test/fixtures/baseApp'
+);
+
+const func = () => {
+  cp.execSync(`cd ${baseApp};${cli} invoke -f http --clean=false`);
+};
+
+const contenders = {
+  'faas-cli invoke': func,
+};
+
+console.log('\nBenchmark:');
+const bench = new Suite().on('cycle', e => {
+  console.log('  ' + e.target);
+});
+
+Object.keys(contenders).forEach(name => {
+  bench.add(name.padEnd(22, ' '), () => contenders[name]());
+});
+
+bench.run();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/lodash": "^4.14.119",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
+    "benchmark": "^2.1.4",
     "gh-pages": "^1.2.0",
     "lerna": "3",
     "lerna-relinker": "^1.4.0",

--- a/packages/faas-cli-plugin-test/src/index.ts
+++ b/packages/faas-cli-plugin-test/src/index.ts
@@ -1,6 +1,4 @@
 import { BasePlugin } from '@midwayjs/fcli-command-core';
-import { TestCommand, CovCommand } from 'midway-bin';
-import * as co from 'co';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
@@ -41,6 +39,8 @@ export class TestPlugin extends BasePlugin {
         this.core.cli.log('Testing all *.test.js/ts...');
       }
       const options = this.options;
+      const { TestCommand, CovCommand } = require('midway-bin');
+      const co = require('co');
       const Command = options.cov ? CovCommand : TestCommand;
       const tester = new Command();
       await co(function*() {

--- a/packages/faas-cli-plugin-test/src/index.ts
+++ b/packages/faas-cli-plugin-test/src/index.ts
@@ -39,7 +39,8 @@ export class TestPlugin extends BasePlugin {
         this.core.cli.log('Testing all *.test.js/ts...');
       }
       const options = this.options;
-      const { TestCommand, CovCommand } = require('midway-bin');
+      const TestCommand = require('midway-bin/lib/cmd/test');
+      const CovCommand = require('midway-bin/lib/cmd/cov');
       const co = require('co');
       const Command = options.cov ? CovCommand : TestCommand;
       const tester = new Command();

--- a/packages/faas-util-ts-compile/src/index.ts
+++ b/packages/faas-util-ts-compile/src/index.ts
@@ -1,6 +1,5 @@
 import { join, relative, resolve } from 'path';
 import { readFileSync, existsSync } from 'fs-extra';
-import { BuildCommand } from 'midway-bin';
 export * from './utils';
 import { combineTsConfig } from './utils';
 
@@ -61,6 +60,7 @@ export const tsCompile = async (
     incremental?: boolean;
   } = {}
 ) => {
+  const BuildCommand = require('midway-bin/lib/cmd/build');
   const builder = new BuildCommand();
   let tsJson = null;
   if (options.tsConfigName) {

--- a/packages/serverless-invoke/src/core.ts
+++ b/packages/serverless-invoke/src/core.ts
@@ -135,6 +135,7 @@ export abstract class InvokeCore implements IInvoke {
         { cwd: baseDir }
       );
       if (!fileChanges || !fileChanges.length) {
+        lockMap[buildLogPath] = true;
         this.debug('Auto skip ts compile');
         return;
       }


### PR DESCRIPTION
+ faas-cli动态加载插件，相关性能对比
from:
```
Benchmark:
  faas-cli invoke        x 0.40 ops/sec ±3.09% (5 runs sampled)
  faas-cli help          x 0.54 ops/sec ±5.14% (6 runs sampled)
  faas-cli test          x 0.48 ops/sec ±0.58% (6 runs sampled)
```
to:
```
Benchmark:
  faas-cli invoke        x 0.57 ops/sec ±0.71% (6 runs sampled)
  faas-cli help          x 0.54 ops/sec ±0.64% (6 runs sampled)
  faas-cli test          x 0.87 ops/sec ±0.54% (7 runs sampled)
```

即：
invoke 提升 42.5%
help 无提升
test 提升 81.25%