### PR TITLE
fix: fix send json when fc use http trigger

### DIFF
--- a/packages/faas-dev-pack/test/index.test.ts
+++ b/packages/faas-dev-pack/test/index.test.ts
@@ -109,7 +109,6 @@ describe('/test/index.test.ts', () => {
   });
 
   describe('test buffer return', () => {
-
     it('test buffer result koa in http trigger', (done) => {
       const app = new koa();
       app.use(
@@ -167,7 +166,5 @@ describe('/test/index.test.ts', () => {
         .expect(/hello world/)
         .expect(200, done);
     });
-
   });
-
 });

--- a/packages/serverless-fc-starter/src/runtime.ts
+++ b/packages/serverless-fc-starter/src/runtime.ts
@@ -84,33 +84,30 @@ export class FCRuntime extends ServerlessLightRuntime {
         }
 
         let encoded = false;
-        if (!isHTTPMode) {
-          const data = ctx.body;
-          if (typeof data === 'string') {
-            if (!ctx.type) {
-              ctx.type = 'text/plain';
-            }
-            ctx.body = data;
-          } else if (Buffer.isBuffer(data)) {
-            encoded = true;
-            if (!ctx.type) {
-              ctx.type = 'application/octet-stream';
-            }
-            ctx.body = data.toString('base64');
-          } else if (typeof data === 'object') {
-            if (!ctx.type) {
-              ctx.type = 'application/json';
-            }
-            ctx.body = JSON.stringify(data);
-          } else {
-            // 阿里云网关必须返回字符串
-            if (!ctx.type) {
-              ctx.type = 'text/plain';
-            }
-            ctx.body = data + '';
+        const data = ctx.body;
+        if (typeof data === 'string') {
+          if (!ctx.type) {
+            ctx.type = 'text/plain';
           }
+          ctx.body = data;
+        } else if (Buffer.isBuffer(data)) {
+          encoded = true;
+          if (!ctx.type) {
+            ctx.type = 'application/octet-stream';
+          }
+          ctx.body = data.toString('base64');
+        } else if (typeof data === 'object') {
+          if (!ctx.type) {
+            ctx.type = 'application/json';
+          }
+          ctx.body = JSON.stringify(data);
+        } else {
+          // 阿里云网关必须返回字符串
+          if (!ctx.type) {
+            ctx.type = 'text/plain';
+          }
+          ctx.body = data + '';
         }
-
         const newHeader = {};
 
         for (const key in ctx.res.headers) {

--- a/packages/serverless-fc-starter/src/runtime.ts
+++ b/packages/serverless-fc-starter/src/runtime.ts
@@ -84,7 +84,8 @@ export class FCRuntime extends ServerlessLightRuntime {
         }
 
         let encoded = false;
-        const data = ctx.body;
+
+        let data = ctx.body;
         if (typeof data === 'string') {
           if (!ctx.type) {
             ctx.type = 'text/plain';
@@ -95,19 +96,24 @@ export class FCRuntime extends ServerlessLightRuntime {
           if (!ctx.type) {
             ctx.type = 'application/octet-stream';
           }
+
+          // data is reserved as buffer
           ctx.body = data.toString('base64');
         } else if (typeof data === 'object') {
           if (!ctx.type) {
             ctx.type = 'application/json';
           }
-          ctx.body = JSON.stringify(data);
+          // set data to string
+          ctx.body = data = JSON.stringify(data);
         } else {
           // 阿里云网关必须返回字符串
           if (!ctx.type) {
             ctx.type = 'text/plain';
           }
-          ctx.body = data + '';
+          // set data to string
+          ctx.body = data = data + '';
         }
+
         const newHeader = {};
 
         for (const key in ctx.res.headers) {
@@ -138,7 +144,8 @@ export class FCRuntime extends ServerlessLightRuntime {
         }
 
         if (res.send) {
-          res.send(ctx.body);
+          // http trigger only support `Buffer` or a `string` or a `stream.Readable`
+          res.send(data);
         }
 
         return {

--- a/packages/serverless-fc-starter/test/fixtures/http-json/index.ts
+++ b/packages/serverless-fc-starter/test/fixtures/http-json/index.ts
@@ -1,0 +1,16 @@
+import { asyncWrapper, start } from '../../../src';
+
+let runtime;
+let inited;
+
+exports.handler = asyncWrapper(async (...args) => {
+  if (!inited) {
+    inited = true;
+    runtime = await start();
+  }
+  return runtime.asyncEvent(async function (ctx) {
+    ctx.body = {
+      name: 'Alan',
+    };
+  })(...args);
+});

--- a/packages/serverless-fc-starter/test/index.test.ts
+++ b/packages/serverless-fc-starter/test/index.test.ts
@@ -423,6 +423,25 @@ describe('/test/index.test.ts', () => {
       await runtime.close();
     });
 
+    it('should invoke normal code', async () => {
+      const runtime = createRuntime({
+        functionDir: join(__dirname, './fixtures/http-json'),
+      });
+      await runtime.start();
+      const result = await runtime.invoke(
+        new HTTPTrigger({
+          path: '/help',
+          method: 'GET',
+        })
+      );
+      assert.equal(
+        result.headers['content-type'],
+        'application/json; charset=utf-8'
+      );
+      assert.equal(result.body, '{"name":"Alan"}');
+      await runtime.close();
+    });
+
     it('should invoke with api gateway', async () => {
       const runtime = createRuntime({
         functionDir: join(__dirname, './fixtures/apigw'),


### PR DESCRIPTION
if we use `res.send(json)` in http trigger, fc will be throw error.

> TypeError: buffer should be a `Buffer` or a `string` or a `stream.Readable`