### PR TITLE
fix: strip all the * of end of 2 paths, no * is first

### DIFF
--- a/packages/gateway-common-http/src/common.ts
+++ b/packages/gateway-common-http/src/common.ts
@@ -62,17 +62,21 @@ export async function parseInvokeOptionsByOriginUrl(
   // 2. 星号只能出现最后且必须在/后面，如 /ab/cb/**
   // 3. 如果绝对路径和通配都能匹配一个路径时，绝对规则优先级高
   // 4. 有多个通配能匹配一个路径时，最长的规则匹配，如 /ab/** 和 /ab/cd/** 在匹配 /ab/cd/f 时命中 /ab/cd/**
+  // 5. 如果 / 与 /* 都能匹配 / ,但 / 的优先级高于 /*
   urlMatchList = urlMatchList
     .map(item => {
-      const router = item.router.replace(/\**$/, '');
       return {
         functionName: item.functionName,
         router: item.router,
+        pureRouter: item.router.replace(/\**$/, ''),
         originRouter: item.originRouter,
-        level: router.split('/').length - 1,
+        level: item.router.split('/').length - 1,
       };
     })
     .sort((handlerA, handlerB) => {
+      if (handlerA.pureRouter === handlerB.pureRouter) {
+        return handlerA.router.length - handlerB.router.length;
+      }
       return handlerB.level - handlerA.level;
     });
 

--- a/packages/gateway-common-http/test/fixtures/ice-demo-repo/f.yml
+++ b/packages/gateway-common-http/test/fixtures/ice-demo-repo/f.yml
@@ -31,3 +31,8 @@ functions:
     events:
       - http:
           path: /ignore.do
+  test6:
+    handler: test6.handler
+    events:
+      - apigw:
+          path: /api/

--- a/packages/gateway-common-http/test/fixtures/ice-demo-repo/src/apis/test6.ts
+++ b/packages/gateway-common-http/test/fixtures/ice-demo-repo/src/apis/test6.ts
@@ -1,0 +1,18 @@
+import {
+  provide,
+  func,
+  FunctionHandler,
+  inject,
+  FaaSContext,
+} from '@midwayjs/faas';
+
+@provide()
+@func('test6.handler')
+export class Test6Handler implements FunctionHandler {
+  @inject()
+  ctx: FaaSContext;
+
+  async handler() {
+    this.ctx.body = {data: 'test6'};
+  }
+}

--- a/packages/gateway-common-http/test/index.test.ts
+++ b/packages/gateway-common-http/test/index.test.ts
@@ -137,6 +137,19 @@ describe('/test/index.test.ts', () => {
         .expect(/test3/)
         .expect(200, done);
     });
+
+    it('test /api/ router', done => {
+      createExpressSuit({
+        functionDir: join(__dirname, './fixtures/ice-demo-repo'),
+        sourceDir: 'src/apis',
+      })
+        .post('/api/')
+        .query({
+          action: 'doTest',
+        })
+        .expect(/test6/)
+        .expect(200, done);
+    });
   });
 
   it('should invoke by http api and koa', done => {


### PR DESCRIPTION
去掉所有结尾的\*后俩路径如果相同，那么没有\*的优先。
/* vs / ,优先匹配 /
/a* vs /a ，优先匹配 /a